### PR TITLE
Add simple UI for 2 video args: no-video and size

### DIFF
--- a/lib/application/args_bloc/args_bloc.dart
+++ b/lib/application/args_bloc/args_bloc.dart
@@ -1,11 +1,9 @@
+import 'dart:math';
+
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:fpdart/fpdart.dart';
-
-// ignore: unused_import
-import 'package:scrcpy_buddy/application/model/scrcpy/scrcpy_arg.dart';
 import 'package:scrcpy_buddy/application/model/scrcpy/scrcpy_cli_argument.dart';
-import 'package:scrcpy_buddy/main.dart';
 
 part 'args_event.dart';
 
@@ -14,30 +12,30 @@ part 'args_state.dart';
 typedef _Emitter = Emitter<ArgsState>;
 
 class ArgsBloc extends Bloc<ArgsEvent, ArgsState> {
-  ArgsBloc() : super(ArgsInitial()) {
+  ArgsBloc() : super(ArgsInitial({})) {
     on<UpdateArgsEvent>(_updateArg);
     on<InitializeArgsEvent>(_initializeArgs);
   }
 
-  final _args = <String, dynamic>{};
+  final _args = <ScrcpyCliArgument, dynamic>{};
 
-  final _argsInstances = scrcpyArg.annotatedClasses
-      .map((c) => c.newInstance('', []) as ScrcpyCliArgument)
-      .toList(growable: false);
+  // final _argsInstances = scrcpyArg.annotatedClasses
+  //     .map((c) => c.newInstance('', []) as ScrcpyCliArgument)
+  //     .toList(growable: false);
 
   void _updateArg(UpdateArgsEvent event, _Emitter emit) {
-    _args[event.key] = event.value;
+    if (event.value == null) {
+      _args.remove(event.arg);
+    } else {
+      _args[event.arg] = event.value;
+    }
     emit(ArgsUpdatedState(_args));
   }
 
   void _initializeArgs(InitializeArgsEvent _, _Emitter emit) {
-    _args.putIfAbsent(VideoSize().label, () => "1280");
+    // TODO: Load saved args/profiles
     emit(ArgsUpdatedState(_args));
   }
 
-  List<String> calculateArgsList() => _args.keys
-      .map((key) => _argsInstances.where((argInstance) => argInstance.label == key).first)
-      .map((argumentInstance) => argumentInstance.toArgs(_args[argumentInstance.label]))
-      .flatten
-      .toList(growable: false);
+  List<String> calculateArgsList() => _args.entries.map((entry) => entry.key.toArgs(entry.value)).flatten.toList();
 }

--- a/lib/application/args_bloc/args_event.dart
+++ b/lib/application/args_bloc/args_event.dart
@@ -12,11 +12,11 @@ class InitializeArgsEvent extends ArgsEvent {
 }
 
 class UpdateArgsEvent<V> extends ArgsEvent {
-  final String key;
+  final ScrcpyCliArgument<V> arg;
   final V? value;
 
-  const UpdateArgsEvent(this.key, this.value);
+  const UpdateArgsEvent(this.arg, this.value);
 
   @override
-  List<Object?> get props => [key, value];
+  List<Object?> get props => [arg, value];
 }

--- a/lib/application/args_bloc/args_state.dart
+++ b/lib/application/args_bloc/args_state.dart
@@ -1,19 +1,25 @@
 part of 'args_bloc.dart';
 
 sealed class ArgsState extends Equatable {
-  const ArgsState();
+  final Map<ScrcpyCliArgument, dynamic> args;
+
+  // ignore: prefer_const_constructors_in_immutables
+  ArgsState(this.args);
+
+  @override
+  List<Object?> get props {
+    if (args.isEmpty) {
+      return [Random().nextInt(9999)];
+    } else {
+      return args.entries.toList(growable: false);
+    }
+  }
 }
 
 final class ArgsInitial extends ArgsState {
-  @override
-  List<Object> get props => [];
+  ArgsInitial(super.args);
 }
 
 final class ArgsUpdatedState extends ArgsState {
-  final Map<String, dynamic> args;
-
-  const ArgsUpdatedState(this.args);
-
-  @override
-  List<Object> get props => [args];
+  ArgsUpdatedState(super.args);
 }

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -4,7 +4,6 @@ import 'package:go_router/go_router.dart';
 import 'package:scrcpy_buddy/application/args_bloc/args_bloc.dart';
 import 'package:scrcpy_buddy/application/model/scrcpy/scrcpy_error.dart';
 import 'package:scrcpy_buddy/application/scrcpy_bloc/scrcpy_bloc.dart';
-import 'package:scrcpy_buddy/presentation/devices/bloc/devices_bloc.dart';
 import 'package:scrcpy_buddy/presentation/extension/context_extension.dart';
 import 'package:scrcpy_buddy/presentation/extension/translation_extension.dart';
 import 'package:scrcpy_buddy/presentation/home/console_section/console_section.dart';
@@ -23,7 +22,6 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends AppModuleState<HomeScreen> {
-  late final _scrcpyBloc = context.read<ScrcpyBloc>();
   late final _argsBloc = context.read<ArgsBloc>();
 
   final _devicesKey = ValueKey('devices');

--- a/lib/presentation/scrcpy_config/video_screen.dart
+++ b/lib/presentation/scrcpy_config/video_screen.dart
@@ -1,5 +1,11 @@
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:scrcpy_buddy/application/args_bloc/args_bloc.dart';
+import 'package:scrcpy_buddy/presentation/scrcpy_config/widgets/config_item.dart';
+import 'package:scrcpy_buddy/presentation/scrcpy_config/widgets/config_text_box.dart';
 import 'package:scrcpy_buddy/presentation/widgets/app_widgets.dart';
+
+import 'package:scrcpy_buddy/application/model/scrcpy/scrcpy_arg.dart';
 
 class VideoScreen extends StatefulWidget {
   const VideoScreen({super.key});
@@ -9,11 +15,50 @@ class VideoScreen extends StatefulWidget {
 }
 
 class _VideoScreenState extends AppModuleState<VideoScreen> {
+  late final _argsBloc = context.read<ArgsBloc>();
+
   @override
   String get module => 'config.video';
 
   @override
   Widget build(BuildContext context) {
-    return Text(translatedText(key: 'title'));
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: BlocBuilder<ArgsBloc, ArgsState>(
+        buildWhen: (_, _) => true,
+        builder: (context, state) {
+          return SingleChildScrollView(
+            child: Card(
+              padding: EdgeInsets.zero,
+              child: Column(
+                mainAxisSize: .min,
+                crossAxisAlignment: .stretch,
+                children: [
+                  ConfigItem(
+                    label: 'video.noVideo',
+                    child: ToggleSwitch(
+                      checked: state.args[NoVideo()] ?? false,
+                      onChanged: (checked) => _argsBloc.add(UpdateArgsEvent(NoVideo(), checked)),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  const Divider(),
+                  const SizedBox(height: 8),
+                  ConfigItem(
+                    label: 'video.size',
+                    child: ConfigTextBox(
+                      value: state.args[VideoSize()],
+                      isNumberOnly: true,
+                      onChanged: (newValue) =>
+                          _argsBloc.add(UpdateArgsEvent(VideoSize(), newValue)),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
   }
 }

--- a/lib/presentation/scrcpy_config/widgets/config_item.dart
+++ b/lib/presentation/scrcpy_config/widgets/config_item.dart
@@ -1,0 +1,56 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:scrcpy_buddy/presentation/extension/context_extension.dart';
+import 'package:scrcpy_buddy/presentation/widgets/app_widgets.dart';
+
+class ConfigItem extends AppStatelessWidget {
+  final String label;
+  final Widget child;
+
+  const ConfigItem({super.key, required this.label, required this.child});
+
+  @override
+  String get module => 'config.$label';
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+      child: Row(
+        children: [
+          Expanded(
+            flex: 5,
+            child: Column(
+              mainAxisSize: .min,
+              crossAxisAlignment: .stretch,
+              children: [
+                Row(
+                  children: [
+                    Text(translatedText(context, key: 'title'), style: context.typography.bodyStrong),
+                    const SizedBox(width: 8),
+                    Tooltip(
+                      richMessage: TextSpan(
+                        text: translatedText(context, key: 'arg'),
+                        style: TextStyle(fontFamily: 'monospace'),
+                      ),
+                      child: CircleAvatar(
+                        radius: 10,
+                        backgroundColor: context.theme.resources.subtleFillColorSecondary,
+                        child: WindowsIcon(WindowsIcons.help, size: 8),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Text(translatedText(context, key: 'description'), style: context.typography.body),
+              ],
+            ),
+          ),
+          const SizedBox(width: 16),
+          Flexible(
+            child: Align(alignment: Alignment.centerRight, child: child),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/scrcpy_config/widgets/config_text_box.dart
+++ b/lib/presentation/scrcpy_config/widgets/config_text_box.dart
@@ -1,0 +1,49 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/services.dart';
+
+class ConfigTextBox extends StatefulWidget {
+  final String? value;
+  final bool isNumberOnly;
+  final void Function(String? newValue) onChanged;
+
+  const ConfigTextBox({super.key, required this.value, required this.isNumberOnly, required this.onChanged});
+
+  @override
+  State<ConfigTextBox> createState() => _ConfigTextBoxState();
+}
+
+class _ConfigTextBoxState extends State<ConfigTextBox> {
+  late final _controller = TextEditingController(text: widget.value);
+
+  @override
+  void didUpdateWidget(covariant ConfigTextBox oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.value == null) {
+      _controller.clear();
+    } else if (widget.value != oldWidget.value && widget.value != _controller.text) {
+      _controller.text = widget.value!.toString();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextBox(
+      controller: _controller,
+      inputFormatters: widget.isNumberOnly ? [FilteringTextInputFormatter.digitsOnly] : null,
+      suffix: _controller.text.isNotEmpty ? IconButton(icon: WindowsIcon(WindowsIcons.clear), onPressed: () => widget.onChanged(null)) : null,
+      onChanged: (newValue) {
+        if (newValue.isEmpty) {
+          widget.onChanged(null);
+        } else {
+          widget.onChanged(newValue);
+        }
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1131,5 +1131,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"
   flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.10.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
- Upgrade project to use short-hand enum operators (introduced in Flutter 3.38)

<img width="834" height="744" alt="image" src="https://github.com/user-attachments/assets/83111974-92d9-4ce2-a283-0572e6964a68" />
